### PR TITLE
fix(zoom): only get pane info when not in an overlay

### DIFF
--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -140,7 +140,7 @@ wez.on("update-status", function(window, pane)
     table.insert(left_cells, { Text = stat })
   end
 
-  if options.modules.zoom.enabled then
+  if options.modules.zoom.enabled and pane:tab() then
     local panes_with_info = pane:tab():panes_with_info()
     for _, p in ipairs(panes_with_info) do
       if p.is_active and p.is_zoomed then


### PR DESCRIPTION
I enabled the zoom module tonight and while testing some other things noticed the debug overlay errors mentioned in #44. The `pane:tab()` [docs](https://wezterm.org/config/lua/pane/tab.html) state

> Note that this method can return nil when pane is a GUI-managed overlay pane (such as the debug overlay), because those panes are not managed by the mux layer.

So it makes sense that the error was showing when opening the debug overlay! Adding a quick check for `nil` after confirming the zoom module is enabled will prevent this.

Closes #44