### PR TITLE
feat: add configurable background colors for tabs

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,8 +88,11 @@ local config = {
   modules = {
     tabs = {
       active_tab_fg = 4,
+      active_tab_bg = "transparent",
       inactive_tab_fg = 6,
+      inactive_tab_bg = "transparent",
       new_tab_fg = 2,
+      new_tab_bg = "transparent",
     },
     workspace = {
       enabled = true,
@@ -146,30 +149,34 @@ local config = {
 ### 🎨 Colors
 
 Every ansi color used is configurable, to change a color, pass in the desired
-ansi code to use for a specific setting.
+ansi code to use for a specific setting. You can use either an ansi color index
+(number) or a hex color string (e.g., `"#c6a0f6"`).
 
-If you want to change any other color used, since the plugin uses your themes colors you can configure the theme to get a different result. For instance, if I want to change the active tab background color I can do so like this:
+Tab background colors can be configured via the `modules.tabs` options:
 
 ```lua
-return {
-  -- ... your existing config
-  colors = {
-    tab_bar = {
-      active_tab = {
-        bg_color = "#26233a"
-      }
-    }
-  }
-}
+bar.apply_to_config(config, {
+  modules = {
+    tabs = {
+      active_tab_fg = 1,
+      active_tab_bg = 6,           -- ansi color index
+      -- or use a hex color:
+      -- active_tab_bg = "#c6a0f6",
+    },
+  },
+})
 ```
 
 #### 🖌️ Color table
 
-| Color option                    | Default       |
-| ------------------------------- | ------------- |
-| `tab_bar.background`            | `transparent` |
-| `tab_bar.active_tab.bg_color`   | `transparent` |
-| `tab_bar.inactive_tab.bg_color` | `transparent` |
+| Config option       | Default       |
+| ------------------- | ------------- |
+| `active_tab_fg`     | `4`           |
+| `active_tab_bg`     | `transparent` |
+| `inactive_tab_fg`   | `6`           |
+| `inactive_tab_bg`   | `transparent` |
+| `new_tab_fg`        | `2`           |
+| `new_tab_bg`        | `transparent` |
 
 ## 📜 License
 

--- a/plugin/bar/config.lua
+++ b/plugin/bar/config.lua
@@ -12,9 +12,12 @@ local M = {}
 ---@field field_icon string
 
 ---@class option.tabs
----@field active_tab_fg number
----@field inactive_tab_fg number
----@field new_tab_fg number
+---@field active_tab_fg number|string
+---@field active_tab_bg number|string
+---@field inactive_tab_fg number|string
+---@field inactive_tab_bg number|string
+---@field new_tab_fg number|string
+---@field new_tab_bg number|string
 
 ---@class option.module
 ---@field enabled boolean
@@ -72,8 +75,11 @@ M.options = {
   modules = {
     tabs = {
       active_tab_fg = 4,
+      active_tab_bg = "transparent",
       inactive_tab_fg = 6,
+      inactive_tab_bg = "transparent",
       new_tab_fg = 2,
+      new_tab_bg = "transparent",
     },
     workspace = {
       enabled = true,

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -4,24 +4,38 @@ local wez = require "wezterm"
 local M = {}
 local options = {}
 
+---resolves a color option: if it is a number use it as an ansi index,
+---otherwise treat it as a color string
+---@param value string|number|nil
+---@param scheme table
+---@param fallback string
+---@return string
+local function resolve_color(value, scheme, fallback)
+  if type(value) == "number" then
+    return scheme.ansi[value] or fallback
+  end
+  return value or fallback
+end
+
 ---builds tab_bar colors block from a resolved color scheme
 ---@param scheme table
 ---@return table
 local function build_tab_bar_colors(scheme)
+  local tabs = options.modules.tabs
   return {
     tab_bar = {
       background = "transparent",
       active_tab = {
-        bg_color = "transparent",
-        fg_color = scheme.ansi[options.modules.tabs.active_tab_fg],
+        bg_color = resolve_color(tabs.active_tab_bg, scheme, "transparent"),
+        fg_color = resolve_color(tabs.active_tab_fg, scheme, "white"),
       },
       inactive_tab = {
-        bg_color = "transparent",
-        fg_color = scheme.ansi[options.modules.tabs.inactive_tab_fg],
+        bg_color = resolve_color(tabs.inactive_tab_bg, scheme, "transparent"),
+        fg_color = resolve_color(tabs.inactive_tab_fg, scheme, "white"),
       },
       new_tab = {
-        bg_color = "transparent",
-        fg_color = scheme.ansi[options.modules.tabs.new_tab_fg],
+        bg_color = resolve_color(tabs.new_tab_bg, scheme, "transparent"),
+        fg_color = resolve_color(tabs.new_tab_fg, scheme, "white"),
       },
     },
   }


### PR DESCRIPTION
## Summary
- Add `active_tab_bg`, `inactive_tab_bg`, and `new_tab_bg` options to `modules.tabs` config
- Values accept either an ansi color index (number) or a hex color string (e.g., `"#c6a0f6"`)
- Defaults to `"transparent"` to preserve current behavior
- Add `resolve_color` helper to handle both number and string color values for fg and bg options

## Example usage

```lua
bar.apply_to_config(config, {
  modules = {
    tabs = {
      active_tab_fg = 1,
      active_tab_bg = 6,           -- ansi color index
      -- or use a hex color:
      -- active_tab_bg = "#c6a0f6",
    },
  },
})
```