### PR TITLE
feat: add ssh module for remote session detection

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,14 @@ A tab bar configuration for wezterm, this configuration is heavily inspired by [
 > [!IMPORTANT]
 > The plugin will not work if `config.enable_tab_bar` is set to `false`. Make sure the tab bar is enabled (this is the default wezterm behavior, so you only need to act if you have explicitly disabled it).
 
+### 🔐 SSH
+
+The SSH module detects when the active pane is running an SSH session and displays an indicator in the right status bar. When enabled, it automatically hides the `cwd` module during SSH sessions, since the remote working directory is not available to WezTerm without OSC 7 configuration on the remote host.
+
+> [!NOTE]
+> bar.wezterm ships with this module disabled, please check example in
+> [Configuration](#%EF%B8%8F-configuration) on how to enable it.
+
 ### 🎵Spotify
 
 In order for the spotify integration to work you need to have [spotify-tui](https://github.com/Rigellute/spotify-tui) installed on you system. Follow their installation instructions on how to set it up.
@@ -134,6 +142,11 @@ local config = {
       enabled = true,
       icon = wez.nerdfonts.oct_file_directory,
       color = 7,
+    },
+    ssh = {
+      enabled = false,
+      icon = wez.nerdfonts.md_ssh,
+      color = 5,
     },
     spotify = {
       enabled = false,

--- a/plugin/bar/config.lua
+++ b/plugin/bar/config.lua
@@ -40,6 +40,7 @@ local M = {}
 ---@field hostname option.module
 ---@field clock option.clock
 ---@field cwd option.module
+---@field ssh option.module
 ---@field spotify option.spotify
 
 ---@class option.padding.tabs
@@ -121,6 +122,11 @@ M.options = {
       enabled = true,
       icon = wez.nerdfonts.oct_file_directory,
       color = 7,
+    },
+    ssh = {
+      enabled = false,
+      icon = wez.nerdfonts.md_ssh,
+      color = 5,
     },
     spotify = {
       enabled = false,

--- a/plugin/init.lua
+++ b/plugin/init.lua
@@ -220,7 +220,26 @@ wez.on("update-status", function(window, pane)
     {
       name = "cwd",
       func = function()
+        if options.modules.ssh.enabled then
+          local process = pane:get_foreground_process_name()
+          if process and (utilities._basename(process) or ""):match "ssh$" then
+            return ""
+          end
+        end
         return paths.get_cwd(pane, true)
+      end,
+    },
+    {
+      name = "ssh",
+      func = function()
+        local process = pane:get_foreground_process_name()
+        if not process then
+          return ""
+        end
+        if (utilities._basename(process) or ""):match "ssh$" then
+          return "ssh"
+        end
+        return ""
       end,
     },
   }


### PR DESCRIPTION
## Summary

- Adds a new `ssh` module that detects when the active pane is running an SSH session and displays an indicator in the right status bar
- When enabled, it automatically hides the `cwd` module during SSH sessions, since the remote working directory is not available to WezTerm without OSC 7 configuration on the remote host
- The module is disabled by default and follows the same pattern as existing modules (enabled, icon, color)

### Usage

```lua
bar.apply_to_config(config, {
  modules = {
    ssh = {
      enabled = true,
    },
  },
})
```

### Default configuration

```lua
ssh = {
  enabled = false,
  icon = wez.nerdfonts.md_ssh,
  color = 5,
},
```